### PR TITLE
BiometricScheduler: Cancel operation if not idle

### DIFF
--- a/services/core/java/com/android/server/biometrics/sensors/BiometricScheduler.java
+++ b/services/core/java/com/android/server/biometrics/sensors/BiometricScheduler.java
@@ -382,8 +382,8 @@ public class BiometricScheduler {
 
     protected void startNextOperationIfIdle() {
         if (mCurrentOperation != null) {
-            Slog.v(getTag(), "Not idle, current operation: " + mCurrentOperation);
-            return;
+            Slog.v(getTag(), "Not idle, cancelling current operation: " + mCurrentOperation);
+            cancelInternal(mCurrentOperation);
         }
         if (mPendingOperations.isEmpty()) {
             Slog.d(getTag(), "No operations, returning to idle");


### PR DESCRIPTION
- some hals fail to report success/failure (for ex. realme fp hals)

Signed-off-by: SagarMakhar <sagarmakhar@gmail.com>